### PR TITLE
feat: tag with commit hash

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,12 @@ on:
       buildImage:
         description: 'Build Docker Image according to the environment'
         default: 'false'
+      commitVersionTag:
+        description: 'The image tag will be retrieved from the bee version command'
+        default: 'false'
+      beeVersion:
+        description: 'The official bee image tag that the image will be built on'
+        default: 'latest'
   push:
     branches:
       - 'master'
@@ -38,6 +44,8 @@ jobs:
         run: |
           npm run build:env
       - name: Publish if it was clicked manually
-        if: ${{ github.event.inputs.buildImage }} == 'true' && success()
+        if: "${{ github.event.inputs.buildImage }}" == 'true' && success()
         run: |
+          COMMIT_VERSION_TAG="${{ github.event.inputs.commitVersionTag }}"
+          BEE_VERSION="${{ github.event.inputs.beeVersion }}"
           npm run publish:env

--- a/scripts/.env
+++ b/scripts/.env
@@ -1,4 +1,5 @@
-BEE_VERSION="0.5.3"
+BEE_VERSION="latest"
 BLOCKCHAIN_VERSION="1.0.0"
 BEE_ENV_PREFIX="swarm-test"
 BEE_IMAGE_PREFIX="docker.pkg.github.com/ethersphere/bee-factory"
+COMMIT_VERSION_TAG="true"

--- a/scripts/.env
+++ b/scripts/.env
@@ -1,4 +1,4 @@
-BEE_VERSION="latest"
+BEE_VERSION="0.5.3"
 BLOCKCHAIN_VERSION="1.0.0"
 BEE_ENV_PREFIX="swarm-test"
 BEE_IMAGE_PREFIX="docker.pkg.github.com/ethersphere/bee-factory"

--- a/scripts/bee-cleanup.sh
+++ b/scripts/bee-cleanup.sh
@@ -15,8 +15,8 @@ done
 
 echo "Removing built Bee Docker images..."
 
+BEE_VERSION=$("$MY_PATH/utils/build-image-tag.sh" get)
 BEE_ENV_PREFIX=$("$MY_PATH/utils/env-variable-value.sh" BEE_ENV_PREFIX)
-BEE_VERSION=$("$MY_PATH/utils/env-variable-value.sh" BEE_VERSION)
 BEE_IMAGE_PREFIX=$("$MY_PATH/utils/env-variable-value.sh" BEE_IMAGE_PREFIX)
 DOCKER_IMAGES=$(docker image ls -qaf reference="$BEE_IMAGE_PREFIX/$BEE_ENV_PREFIX*:$BEE_VERSION")
 for DOCKER_IMAGE in $DOCKER_IMAGES

--- a/scripts/bee-docker-build.sh
+++ b/scripts/bee-docker-build.sh
@@ -29,6 +29,15 @@ sudo chmod 777 -R "$MY_PATH/bee-data-dirs"
 echo "Update common dockerfile"
 dockerfile "$MY_PATH/bee-data-dirs/Dockerfile" "$BEE_VERSION"
 
+# If the user has been set the COMMIT_VERSION_TAG env variable
+# The image will be built with the tag that is the bee version string
+COMMIT_VERSION_TAG="$("$MY_PATH/utils/env-variable-value.sh" COMMIT_VERSION_TAG)"
+if [ "$COMMIT_VERSION_TAG" == "true" ] ; then
+  # somehow the version command's output goes to the stderr
+  BEE_VERSION=$(docker run --rm ethersphere/bee:$BEE_VERSION version 2>&1)
+  "$MY_PATH/utils/build-image-tag.sh" set "$BEE_VERSION"
+fi
+
 echo "Build Dockerfiles"
 for BEE_DIR in $BEE_DIRS
 do

--- a/scripts/bee.sh
+++ b/scripts/bee.sh
@@ -59,8 +59,8 @@ log_queen() {
 MY_PATH=$(dirname "$0")              # relative
 MY_PATH=$( cd "$MY_PATH" && pwd )  # absolutized and normalized
 # Check used system variable set
+BEE_VERSION=$("$MY_PATH/utils/build-image-tag.sh" get)
 BEE_IMAGE_PREFIX=$("$MY_PATH/utils/env-variable-value.sh" BEE_IMAGE_PREFIX)
-BEE_VERSION=$("$MY_PATH/utils/env-variable-value.sh" BEE_VERSION)
 BEE_ENV_PREFIX=$("$MY_PATH/utils/env-variable-value.sh" BEE_ENV_PREFIX)
 
 # Init variables

--- a/scripts/utils/.gitignore
+++ b/scripts/utils/.gitignore
@@ -1,0 +1,2 @@
+# ignore tmp file for custom image tag
+.commit-version-tag

--- a/scripts/utils/build-image-tag.sh
+++ b/scripts/utils/build-image-tag.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Store/get the tag of the Docker image that will be built
+
+store_custom_tag() {
+  echo "$1" > "$MY_PATH/$COMMIT_VERSION_TAG_FILENAME"
+}
+
+# Echos the image tag which is defined by the environment or has been extracted from the Bee version command
+get_tag() {
+  COMMIT_VERSION_TAG=$("$MY_PATH/env-variable-value.sh" COMMIT_VERSION_TAG)
+  if [ "$COMMIT_VERSION_TAG" == 'true' ] ; then
+    # retrieve from the output of previous store action
+    cat "$MY_PATH/$COMMIT_VERSION_TAG_FILENAME"
+  else
+    BEE_VERSION=$("$MY_PATH/env-variable-value.sh" BEE_VERSION)
+    echo "$BEE_VERSION"
+  fi
+}
+
+MY_PATH=$(dirname "$0")
+MY_PATH=$( cd "$MY_PATH" && pwd )
+COMMIT_VERSION_TAG_FILENAME=".commit-version-tag"
+
+if [ "$1" == "set" ] ; then
+  store_custom_tag "$2"
+elif [ "$1" == "get" ] ; then
+  get_tag
+fi


### PR DESCRIPTION
introduces new system environment variable: `COMMIT_VERSION_TAG`
the image builder/bee runner scripts can interpret its value as string, which can be either `true` or `false`.
If it is true, then the image which is going to be built will have the tag that is extracted from the `bee version` command.

Closes: #9