### PR TITLE
docs: removed `$` prefix in all shell commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ First you may want to set all global variables that the scripts will use.
 For that, there is a [.env](scripts/.env) file which contains all necessary variables that you need.
 
 ```sh
-$ set -a && source ./scripts/.env && set +a
+set -a && source ./scripts/.env && set +a
 ```
 
 If you do not set these global variables, the scripts will use those which are available in the [.env](scripts/.env) file.
@@ -24,19 +24,19 @@ If you do not set these global variables, the scripts will use those which are a
 Create the common Docker network for the environment with
 
 ```sh
-$ ./scripts/network.sh
+./scripts/network.sh
 ```
 
 To start the blockchain, run the following command in the root directory of the project:
 
 ```sh
-$ ./scripts/blockchain.sh
+./scripts/blockchain.sh
 ```
 
 After that, it's possible to deploy Swarm smart contracts
 
 ```sh
-$ npm run migrate:contracts
+npm run migrate:contracts
 ```
 
 Before you start the Bee nodes with the deployed Swap Factory, you have to fund your overlay addresses of your Bee nodes for the successful start.
@@ -44,7 +44,7 @@ The [supply.js](src/supply.js) script can fund the addresses which are defined i
 To run this script just execute
 
 ```sh
-$ npm run supply
+npm run supply
 ```
 
 and the configured accounts will get 1 ether and 100 BZZ Token.
@@ -52,7 +52,7 @@ and the configured accounts will get 1 ether and 100 BZZ Token.
 After all above went successfully you can start the Bee nodes
 
 ```sh
-$ ./scripts/bee.sh start --workers=4
+./scripts/bee.sh start --workers=4
 ```
 
 OR it is possible to build docker images on a desired state, so that a fresh environment can be started on each run.
@@ -63,11 +63,11 @@ Basically, a full-featured Bee environment has 2 types of Docker image:
 
 - Bee images: Bee clients with pre-defined keys (and optionally including the state which you nodes have in its [data-dirs](scripts/bee-data-dirs))
 ```sh
-$ ./scripts/bee-docker-build.sh
+./scripts/bee-docker-build.sh
 ```
 - Blockchain image: Ganache blockchain which you may want to take a snapshot of after the contracts are deployed and the pre-defined Bee client keys are funded already.
 ```sh
-$ ./scripts/blockchain-docker-build.sh
+./scripts/blockchain-docker-build.sh
 ```
 
 ## Run Environment
@@ -76,5 +76,5 @@ If you have all Docker images that your [environment file](scripts/.env) require
 start the Bee cluster
 
 ```sh
-$ ./scripts/environment.sh start
+./scripts/environment.sh start
 ```


### PR DESCRIPTION
The rationale is, that the current way is not friendly for copy pasting the commands. The build in "copy" button includes the `$ ` line prefix.