### PR TITLE
feat: parametric traffic gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,17 @@ If you don't specify any parameters it will produce 400 chunks/0.5 sec that the 
 
 The following way you can pass parameter
 
-1. BEE_API_URL - Host that has reachable port to the Bee API. [Array<string>,Default:['http://localhost:1633']]
+1. MIN_CHEQUE_NUMBER - Minimum required cheques for Bee under the given BEE_DEBUG_API_URL. If -1 then it does not check for cheques [Number,Default:-1]
+2. BEE_API_URL;BEE_DEBUG_API_URL - Bee API and Debug API URL separated by semicolon. The random data will sent to the Bee API URL, and the generated cheques will be checked on the Bee Debug URL. The two URLs should belong to different Bee clients as the generated data will propagate from that client to the network. [string,Default:'http://localhost:1633;http://localhost:11635']
 
 ```sh
-$ npm run gen:traffic -- <BEE_API_URL> <BEE_API_URL> <BEE_API_URL> (...)
+$ npm run gen:traffic -- <MIN_CHEQUE_NUMBER> <BEE_API_URL;BEE_DEBUG_API_URL> <BEE_API_URL;BEE_DEBUG_API_URL> (...)
 ```
 
 e.g.
 
 ```sh
-$ npm run gen:traffic -- http://localhost:1633 http://localhost:11633
+$ npm run gen:traffic -- 2 http://localhost:1633;http://localhost:11635
 ```
+
+With the example above, random data will be generated until _minimum_ two cheques will generated on Bee client that serves debug endpoint `http://localhost:11635`

--- a/scripts/gen-traffic.js
+++ b/scripts/gen-traffic.js
@@ -1,7 +1,7 @@
 const axios = require('axios').default;
 const { Bee, BeeDebug } = require('@ethersphere/bee-js');
 
-const SLEEP_BETWEEN_UPLOADS_MS = 100
+const SLEEP_BETWEEN_UPLOADS_MS = 500
 const POSTAGE_STAMPS_AMOUNT = BigInt(10000)
 const POSTAGE_STAMPS_DEPTH = 20
 
@@ -93,10 +93,11 @@ async function genTrafficLoop(hosts, minCheques) {
         const incomingCheques = lastcheques.filter(cheque => !!cheque.lastreceived)
 
         const uncashedCheques = []
-        for(const incomingCheque of incomingCheques) {
-          const lastCashOut = await beeDebug.getLastCashoutAction(incomingCheque.peer)
+        const lastCashOutPromises = incomingCheques.map(({ peer }) => beeDebug.getLastCashoutAction(peer))
+        const lastCashOuts = await Promise.all(lastCashOutPromises)
+        for(const [index, lastCashOut] of lastCashOuts.entries()) {
           if(lastCashOut.uncashedAmount > 0) {
-            uncashedCheques.push(incomingCheque)
+            uncashedCheques.push(incomingCheques[index])
           }
         }
         

--- a/scripts/gen-traffic.js
+++ b/scripts/gen-traffic.js
@@ -1,5 +1,5 @@
 const axios = require('axios').default;
-const Bee = require('@ethersphere/bee-js').Bee;
+const { Bee, BeeDebug } = require('@ethersphere/bee-js');
 
 const SLEEP_BETWEEN_UPLOADS_MS = 100
 const POSTAGE_STAMPS_AMOUNT = BigInt(10000)
@@ -57,26 +57,73 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-async function genTrafficLoop(hosts) {
+/**
+ * 
+ * Generates cheques on the given Bee API EP
+ * 
+ * The hosts parameter has to be assimetric in the API;DEBUG_API paired string
+ * because on the API EP the data will be generated, so the cheques should be 
+ * 
+ * @param {string[]} hosts API;DEBUG_API URL strings of the target Bee (e.g. http://localhost:1633;http://localhost:1635)
+ * @param {number} minCheques 
+ */
+async function genTrafficLoop(hosts, minCheques) {
   const promisses = hosts.map(async (host) => {
-    const bee = new Bee(host)
+    const beeUrls = host.split(';')
+    const beeApiUrl = beeUrls[0]
+    const beeDebugApiUrl = beeUrls[1]
+    const bee = new Bee(beeApiUrl)
+    const beeDebug = new BeeDebug(beeDebugApiUrl)
 
     console.log(`Generating postage stamps on ${host}...`)
     const postageBatchId = await bee.createPostageBatch(POSTAGE_STAMPS_AMOUNT, POSTAGE_STAMPS_DEPTH)
     console.log(`Generated ${postageBatchId} postage stamp on ${host}...`)
 
-    return {bee, postageBatchId}
+    return {bee, beeDebug, postageBatchId}
   })
 
   const bees = await Promise.all(promisses)
 
   while(true) {
     await genTrafficOnOpenPorts(bees)
+    
+    if(!isNaN(minCheques)) {
+      const beesUncashedCheques = []
+      for(const bee of bees) {
+        const beeDebug = bee.beeDebug
+        const { lastcheques } = await beeDebug.getLastCheques()
+        const incomingCheques = lastcheques.filter(cheque => !!cheque.lastreceived)
+
+        const uncashedCheques = []
+        for(const incomingCheque of incomingCheques) {
+          const lastCashOut = await beeDebug.getLastCashoutAction(incomingCheque.peer)
+          if(lastCashOut.uncashedAmount > 0) {
+            uncashedCheques.push(incomingCheque)
+          }
+        }
+        
+        beesUncashedCheques.push(uncashedCheques)
+      }
+
+      if(beesUncashedCheques.every(uncashedCheques => uncashedCheques.length >= minCheques)) {
+        console.log(`Generated at least ${minCheques} for every node on the given Debug API endpoints`,)
+        break
+      } else {
+        console.log(`There is not enough uncashed cheques on Bee node(s)`, beesUncashedCheques.map(beeCheques => beeCheques.length))
+      }
+    }
   
     await sleep(SLEEP_BETWEEN_UPLOADS_MS)
   }
 }
 
-const inputArray = process.argv.slice(2)
-const hosts = inputArray.length > 0 ? inputArray : [ 'http://localhost:1633' ]
-genTrafficLoop(hosts)
+let inputArray = process.argv.slice(2)
+// if there is no related input to the minimum required cheques count, 
+// then the traffic generation will go infinitely
+let minCheques = parseInt(inputArray[0])
+let hosts = inputArray.slice(1)
+if(hosts.length === 0) {
+  hosts = [ 'http://localhost:1633;http://localhost:11635' ]
+}
+
+genTrafficLoop(hosts, minCheques)

--- a/scripts/gen-traffic.js
+++ b/scripts/gen-traffic.js
@@ -69,9 +69,7 @@ function sleep(ms) {
  */
 async function genTrafficLoop(hosts, minCheques) {
   const promisses = hosts.map(async (host) => {
-    const beeUrls = host.split(';')
-    const beeApiUrl = beeUrls[0]
-    const beeDebugApiUrl = beeUrls[1]
+    const [ beeApiUrl,  beeDebugApiUrl ] = host.split(';')
     const bee = new Bee(beeApiUrl)
     const beeDebug = new BeeDebug(beeDebugApiUrl)
 

--- a/scripts/gen-traffic.js
+++ b/scripts/gen-traffic.js
@@ -68,7 +68,7 @@ function sleep(ms) {
  * @param {number} minCheques 
  */
 async function genTrafficLoop(hosts, minCheques) {
-  const promisses = hosts.map(async (host) => {
+  const promises = hosts.map(async (host) => {
     const [ beeApiUrl,  beeDebugApiUrl ] = host.split(';')
     const bee = new Bee(beeApiUrl)
     const beeDebug = new BeeDebug(beeDebugApiUrl)
@@ -80,7 +80,7 @@ async function genTrafficLoop(hosts, minCheques) {
     return {bee, beeDebug, postageBatchId}
   })
 
-  const bees = await Promise.all(promisses)
+  const bees = await Promise.all(promises)
 
   while(true) {
     await genTrafficOnOpenPorts(bees)


### PR DESCRIPTION
Traffic generation script had to be improved by passing the cheque numbers that is desired on a particular Bee node.

For that the traffic generation call structure changed to the following:
```
npm run gen:traffic -- [MIN_CHEQUE_NUMBER] [BEE_URL;BEE_DEBUG_URL] [BEE_URL;BEE_DEBUG_URL] ...
```

By that the script can exit from the infinite loop after the count of the incoming cheques on `BEE_DEBUG_URL` reaches the given `MIN_CHEQUE_NUMBER`. The random data will be generated on `BEE_URL` as it happened so far.

it is the continuation of the #28 PR