### PR TITLE
refactor: traffic gen promise all

### DIFF
--- a/scripts/gen-traffic.js
+++ b/scripts/gen-traffic.js
@@ -90,13 +90,18 @@ async function genTrafficLoop(hosts, minCheques) {
       for(const bee of bees) {
         const beeDebug = bee.beeDebug
         const { lastcheques } = await beeDebug.getLastCheques()
+        console.log('lastcheques', lastcheques)
         const incomingCheques = lastcheques.filter(cheque => !!cheque.lastreceived)
 
         const uncashedCheques = []
+        const lastCashOutPromises = []
         for(const incomingCheque of incomingCheques) {
-          const lastCashOut = await beeDebug.getLastCashoutAction(incomingCheque.peer)
+          lastCashOutPromises.push(beeDebug.getLastCashoutAction(incomingCheque.peer))
+        }
+        const lastCashOuts = await Promise.all(lastCashOutPromises)
+        for(const [index, lastCashOut] of lastCashOuts.entries()) {
           if(lastCashOut.uncashedAmount > 0) {
-            uncashedCheques.push(incomingCheque)
+            uncashedCheques.push(incomingCheques[index])
           }
         }
         

--- a/scripts/gen-traffic.js
+++ b/scripts/gen-traffic.js
@@ -94,10 +94,7 @@ async function genTrafficLoop(hosts, minCheques) {
         const incomingCheques = lastcheques.filter(cheque => !!cheque.lastreceived)
 
         const uncashedCheques = []
-        const lastCashOutPromises = []
-        for(const incomingCheque of incomingCheques) {
-          lastCashOutPromises.push(beeDebug.getLastCashoutAction(incomingCheque.peer))
-        }
+        const lastCashOutPromises = incomingCheques.map(({ peer }) => beeDebug.getLastCashoutAction(peer))
         const lastCashOuts = await Promise.all(lastCashOutPromises)
         for(const [index, lastCashOut] of lastCashOuts.entries()) {
           if(lastCashOut.uncashedAmount > 0) {

--- a/scripts/gen-traffic.js
+++ b/scripts/gen-traffic.js
@@ -1,7 +1,7 @@
 const axios = require('axios').default;
 const { Bee, BeeDebug } = require('@ethersphere/bee-js');
 
-const SLEEP_BETWEEN_UPLOADS_MS = 100
+const SLEEP_BETWEEN_UPLOADS_MS = 500
 const POSTAGE_STAMPS_AMOUNT = BigInt(10000)
 const POSTAGE_STAMPS_DEPTH = 20
 
@@ -90,7 +90,6 @@ async function genTrafficLoop(hosts, minCheques) {
       for(const bee of bees) {
         const beeDebug = bee.beeDebug
         const { lastcheques } = await beeDebug.getLastCheques()
-        console.log('lastcheques', lastcheques)
         const incomingCheques = lastcheques.filter(cheque => !!cheque.lastreceived)
 
         const uncashedCheques = []


### PR DESCRIPTION
As @vojtechsimetka correctly [proposed](https://github.com/ethersphere/bee-factory/pull/35#discussion_r636755811), the cheque requests in traffic generation could happen concurently, that I made in this PR.

Nevertheless, the scripts won't exit from the infinite loop ever, because it overloads the Bee node and won't show up any incoming cheques on the destination node _unless_ you break the infinite loop. 

I guess it can be something related to how Bee handles its ongoing processes, but it seems like if the node processes and pushes continuously chunks, it cannot issue cheques.