### PR TITLE
chore: update bee-js to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gen:traffic": "node ./scripts/gen-traffic.js"
   },
   "dependencies": {
-    "@ethersphere/bee-js": "github:ethersphere/bee-js#bee-0.6.0",
+    "@ethersphere/bee-js": "0.10.0",
     "@openzeppelin/contracts": "^3.1.0",
     "axios": "^0.20.0",
     "truffle": "^5.3.5"


### PR DESCRIPTION
Currently the build is breaking, because `bee-js` depends on a branch that has been deleted. This PR fixes that by using the latest version.