### PR TITLE
feat: build from source

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,8 +59,8 @@ jobs:
         run: |
           if [ $BUILD_IMAGE == 'true' ] ; then
             echo "retrieve built BEE_VERSION value"
-            COMMIT_VERSION_TAG=true
-            BEE_VERSION=$( ./scripts/utils/build-image-tag.sh get )
+            export COMMIT_VERSION_TAG=true
+            export BEE_VERSION=$( ./scripts/utils/build-image-tag.sh get )
             echo "Retreived Bee version: $BEE_VERSION"
           fi
           npm run publish:env

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,6 +53,9 @@ jobs:
         if: ${{ github.event.inputs.beeVersionAsCommitHash == 'true' && success() }}
         run: |
           npm run build:env -- --build-base-bee --base-bee-commit-hash=$BEE_VERSION
+          echo "retrieve built BEE_VERSION value"
+          export COMMIT_VERSION_TAG=true
+          export BEE_VERSION=$( ./scripts/utils/build-image-tag.sh get )
       - name: Publish if it was clicked manually
         if: ${{ github.event.inputs.buildImage == 'true' && success() }}
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Build images using built docker bee image
         if: ${{ github.event.inputs.beeVersionAsCommitHash == 'true' && success() }}
         run: |
-          source ./scripts/build-environment.sh  --build-base-bee --base-bee-commit-hash=$BEE_VERSION
+          npm run build:env -- --build-base-bee --base-bee-commit-hash=$BEE_VERSION
       - name: Publish if it was clicked manually
         if: ${{ github.event.inputs.buildImage == 'true' && success() }}
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,6 +24,7 @@ env:
   BEE_IMAGE_PREFIX: 'docker.pkg.github.com/ethersphere/bee-factory'
   COMMIT_VERSION_TAG: ${{ github.event.inputs.commitVersionTag }}
   BEE_VERSION: ${{ github.event.inputs.beeVersion }}
+  BUILD_IMAGE: ${{ github.event.inputs.beeVersionAsCommitHash }}
 
 jobs:
   bee-images:
@@ -53,10 +54,13 @@ jobs:
         if: ${{ github.event.inputs.beeVersionAsCommitHash == 'true' && success() }}
         run: |
           npm run build:env -- --build-base-bee --base-bee-commit-hash=$BEE_VERSION
-          echo "retrieve built BEE_VERSION value"
-          export COMMIT_VERSION_TAG=true
-          export BEE_VERSION=$( ./scripts/utils/build-image-tag.sh get )
       - name: Publish if it was clicked manually
         if: ${{ github.event.inputs.buildImage == 'true' && success() }}
         run: |
+          if [ $BUILD_IMAGE == 'true' ] ; then
+            echo "retrieve built BEE_VERSION value"
+            COMMIT_VERSION_TAG=true
+            BEE_VERSION=$( ./scripts/utils/build-image-tag.sh get )
+            echo "Retreived Bee version: $BEE_VERSION"
+          fi
           npm run publish:env

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,14 +2,17 @@ on:
   workflow_dispatch:
     inputs:
       buildImage:
-        description: 'Build Docker Image according to the environment'
+        description: 'Build and push Docker Image according to the environment'
         default: 'false'
       commitVersionTag:
         description: 'The image tag will be retrieved from the bee version command'
         default: 'false'
       beeVersion:
         description: 'The official bee image tag that the image will be built on. Default: last supported version'
-        default: '0.5.3'
+        default: 'latest'
+      beeVersionAsCommitHash:
+        description: 'The beeVersion parameter will be interpreted as a source code commit hash that the bee base image will be built on'
+        default: 'false'
   push:
     branches:
       - 'master'
@@ -42,9 +45,14 @@ jobs:
       - name: Install npm deps
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci
-      - name: Build images
+      - name: Build images using base docker bee image
+        if: ${{ github.event.inputs.beeVersionAsCommitHash != 'true' && success() }}
         run: |
           npm run build:env
+      - name: Build images using built docker bee image
+        if: ${{ github.event.inputs.beeVersionAsCommitHash == 'true' && success() }}
+        run: |
+          npm run build:env -- --build-base-bee --base-bee-commit-hash=$BEE_VERSION
       - name: Publish if it was clicked manually
         if: ${{ github.event.inputs.buildImage == 'true' && success() }}
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Build images using built docker bee image
         if: ${{ github.event.inputs.beeVersionAsCommitHash == 'true' && success() }}
         run: |
-          npm run build:env -- --build-base-bee --base-bee-commit-hash=$BEE_VERSION
+          source ./scripts/build-environment.sh  --build-base-bee --base-bee-commit-hash=$BEE_VERSION
       - name: Publish if it was clicked manually
         if: ${{ github.event.inputs.buildImage == 'true' && success() }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 build/
+# In case of building bee image, the bee source code will be cloned to this folder
+bee/

--- a/scripts/build-environment.sh
+++ b/scripts/build-environment.sh
@@ -22,7 +22,7 @@ build_bee() {
     git fetch origin --depth=1 "$COMMIT_HASH"
     git reset --hard FETCH_HEAD
     # Build bee and make docker image
-    BEE_VERSION=${COMMIT_HASH::7}-commit
+    export BEE_VERSION=${COMMIT_HASH::7}-commit
     make binary
     echo "Bee image will be built with version: $BEE_VERSION"
     docker build . -t ethersphere/bee:$BEE_VERSION

--- a/scripts/build-environment.sh
+++ b/scripts/build-environment.sh
@@ -1,6 +1,60 @@
 #!/bin/bash
+usage() {
+    cat << USAGE >&2
+USAGE:
+    $ build-environment.sh [PARAMETERS]
+PARAMETERS:
+    --build-base-bee                    The base bee image will be built from source code
+    --base-bee-commit-hash=string       the source code commit hash of the base bee; Default: HEAD; Dependency: --build-base-bee
+USAGE
+    exit 1
+}
+
+build_bee() {
+    # Clone source code
+    BEE_SOURCE_PATH=$MY_PATH/../bee
+    if [ -d "$BEE_SOURCE_PATH" ] ; then
+        rm -rf "$BEE_SOURCE_PATH"
+    fi
+    mkdir "$BEE_SOURCE_PATH" && cd "$BEE_SOURCE_PATH" || exit
+    git init
+    git remote add origin https://github.com/ethersphere/bee.git
+    git fetch origin --depth=1 "$COMMIT_HASH"
+    git reset --hard FETCH_HEAD
+    # Build bee and make docker image
+    export BEE_VERSION=${COMMIT_HASH::7}-commit
+    make binary
+    echo "Bee image will be built with version: $BEE_VERSION"
+    docker build . -t ethersphere/bee:$BEE_VERSION
+}
+
 MY_PATH=$(dirname "$0")
 MY_PATH=$( cd "$MY_PATH" && pwd )
+COMMIT_HASH=HEAD
+BUILD_BASE_BEE=false
+
+# handle passed options
+while [ $# -gt 0 ]
+do
+    case "$1" in
+        --build-base-bee)
+        BUILD_BASE_BEE=true
+        shift 1
+        ;;
+        --base-bee-commit-hash=*)
+        COMMIT_HASH="${1#*=}"
+        shift 1
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if $BUILD_BASE_BEE ; then 
+    build_bee
+fi
 
 "$MY_PATH/network.sh"
 "$MY_PATH/blockchain.sh"

--- a/scripts/build-environment.sh
+++ b/scripts/build-environment.sh
@@ -27,6 +27,8 @@ build_bee() {
     echo "Bee image will be built with version: $BEE_VERSION"
     docker build . -t ethersphere/bee:$BEE_VERSION
     cd "$MY_PATH" || exit 1
+    # Set build image tag so that other terminal session can retrieve
+    "$MY_PATH/utils/build-image-tag.sh" set "$BEE_VERSION"
 }
 
 MY_PATH=$(dirname "$0")

--- a/scripts/build-environment.sh
+++ b/scripts/build-environment.sh
@@ -16,16 +16,17 @@ build_bee() {
     if [ -d "$BEE_SOURCE_PATH" ] ; then
         rm -rf "$BEE_SOURCE_PATH"
     fi
-    mkdir "$BEE_SOURCE_PATH" && cd "$BEE_SOURCE_PATH" || exit
+    mkdir "$BEE_SOURCE_PATH" && cd "$BEE_SOURCE_PATH" || exit 1
     git init
     git remote add origin https://github.com/ethersphere/bee.git
     git fetch origin --depth=1 "$COMMIT_HASH"
     git reset --hard FETCH_HEAD
     # Build bee and make docker image
-    export BEE_VERSION=${COMMIT_HASH::7}-commit
+    BEE_VERSION=${COMMIT_HASH::7}-commit
     make binary
     echo "Bee image will be built with version: $BEE_VERSION"
     docker build . -t ethersphere/bee:$BEE_VERSION
+    cd "$MY_PATH" || exit 1
 }
 
 MY_PATH=$(dirname "$0")
@@ -62,3 +63,5 @@ npm run migrate:contracts
 npm run supply
 "$MY_PATH/blockchain-docker-build.sh"
 "$MY_PATH/bee-docker-build.sh"
+
+echo "Successfully build bee environment. Please set BEE_VERSION variable to $BEE_VERSION to run the built environment"

--- a/scripts/build-environment.sh
+++ b/scripts/build-environment.sh
@@ -10,6 +10,10 @@ USAGE
     exit 1
 }
 
+echoerr() {
+     >&2 echo "$@"
+}
+
 build_bee() {
     # Clone source code
     BEE_SOURCE_PATH=$MY_PATH/../bee


### PR DESCRIPTION
There was a huge demand for build Bee Factory images based on specific bee docker image that could be built on an arbitrary _git commit hash_. This PR extended the `build-environment.sh` script with that and also solved this building process in the CI worfklow.