### PR TITLE
ci: trigger bee-js bee update

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Override inputs from `workflow_dispatch`
         run: |
-          if [[ '${{ github.event_name }}" == "workflow_dispatch"]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch"]]; then
             echo "BEE_VERSION=${{ github.event.inputs.beeVersion }}" >> $GITHUB_ENV
             echo "BUILD_IMAGE=${{ github.event.inputs.beeVersionAsCommitHash }}" >> $GITHUB_ENV
             echo "COMMIT_VERSION_TAG=${{ github.event.inputs.commitVersionTag }}" >> $GITHUB_ENV

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,12 +47,12 @@ jobs:
 
       - name: Override inputs from `workflow_dispatch`
         run: |
-        if [[ '${{ github.event_name }}" == "workflow_dispatch"]]; then
-          echo "BEE_VERSION=${{ github.event.inputs.beeVersion }}" >> $GITHUB_ENV
-          echo "BUILD_IMAGE=${{ github.event.inputs.beeVersionAsCommitHash }}" >> $GITHUB_ENV
-          echo "COMMIT_VERSION_TAG=${{ github.event.inputs.commitVersionTag }}" >> $GITHUB_ENV
-          echo "STATE_COMMIT=${{ github.event.inputs.stateCommit }}" >> $GITHUB_ENV
-        fi
+          if [[ '${{ github.event_name }}" == "workflow_dispatch"]]; then
+            echo "BEE_VERSION=${{ github.event.inputs.beeVersion }}" >> $GITHUB_ENV
+            echo "BUILD_IMAGE=${{ github.event.inputs.beeVersionAsCommitHash }}" >> $GITHUB_ENV
+            echo "COMMIT_VERSION_TAG=${{ github.event.inputs.commitVersionTag }}" >> $GITHUB_ENV
+            echo "STATE_COMMIT=${{ github.event.inputs.stateCommit }}" >> $GITHUB_ENV
+          fi
 
       - name: Auth to Github Package Docker Registry
         if: ${{ github.event_name == 'repository_dispatch' || (github.event.inputs.buildImage == 'true' && success())  }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -80,7 +80,7 @@ jobs:
           npm run publish:env
 
       - name: Trigger Bee-js PR creation
-        if: ${{ github.event_name == 'repository_dispatch' || (github.event.inputs.buildImage == 'true' && success()) }}
+        if: ${{ github.event_name == 'repository_dispatch' }}
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_GHA_PAT }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Override inputs from `workflow_dispatch`
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch"]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "BEE_VERSION=${{ github.event.inputs.beeVersion }}" >> $GITHUB_ENV
             echo "BUILD_IMAGE=${{ github.event.inputs.beeVersionAsCommitHash }}" >> $GITHUB_ENV
             echo "COMMIT_VERSION_TAG=${{ github.event.inputs.commitVersionTag }}" >> $GITHUB_ENV

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -74,6 +74,16 @@ jobs:
           npm run build:env -- $BUILD_PARAMS
 
       - name: Publish if required
+        id: publish
         if: ${{ github.event_name == 'repository_dispatch' || (github.event.inputs.buildImage == 'true' && success()) }}
         run: |
           npm run publish:env
+
+      - name: Trigger Bee-js PR creation
+        if: ${{ github.event_name == 'repository_dispatch' || (github.event.inputs.buildImage == 'true' && success()) }}
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_GHA_PAT }}
+          repository: ethersphere/bee-js
+          event-type: update-bee
+          client-payload: '{"imageVersion": "${{ steps.publish.outputs.bee-version }}"}'

--- a/scripts/publish-environment.sh
+++ b/scripts/publish-environment.sh
@@ -33,3 +33,9 @@ done
 
 echo "Push Blockchain docker image: $BLOCKCHAIN_IMAGE_NAME"
 docker push "$BLOCKCHAIN_IMAGE_NAME"
+
+# This sets output parameter in Github Actions that
+# is then used to trigger Bee-js PR creation
+if [ $CI == 'true' ]; then
+  echo "::set-output name=bee-version::$BEE_VERSION"
+fi


### PR DESCRIPTION
This add the `repository_dispatch` trigger for bee-js update workflow. It is based on the other CI branch to keep the diff clean. Will rebase once it is merged.