### PR TITLE
ci: use docker images for auto builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ on:
 
 env:
   BEE_IMAGE_PREFIX: 'docker.pkg.github.com/ethersphere/bee-factory'
-  BUILD_IMAGE: 'true'
+  BUILD_IMAGE: 'false'
   COMMIT_VERSION_TAG: 'true'
   STATE_COMMIT: 'true'
   BEE_VERSION: '${{ github.event.client_payload.tag }}'


### PR DESCRIPTION
Today Bee 1.4-rc.2 was released so I was checking if the automation pipeline was working well and noticed my mistake in setting the default for the triggered builds. I used the `BUILD_IMAGE=true` which does not uses the Bee's Docker images, so this is a fix for that.

https://github.com/ethersphere/bee-factory/runs/4291351330?check_suite_focus=true