### PR TITLE
ci: fix correct docker bee version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,6 +54,8 @@ jobs:
             echo "STATE_COMMIT=${{ github.event.inputs.stateCommit }}" >> $GITHUB_ENV
           fi
 
+          echo "BEE_VERSION=${BEE_VERSION/v}" >> $GITHUB_ENV
+
       - name: Auth to Github Package Docker Registry
         if: ${{ github.event_name == 'repository_dispatch' || (github.event.inputs.buildImage == 'true' && success())  }}
         run: |


### PR DESCRIPTION
The version coming from Bee repo comes in form of `v1.4.0` but the Docker images are tagged without the `v`. This is small fix that removes the `v` from the input.