### PR TITLE
fix: commit removing regex honors rc suffix

### DIFF
--- a/src/utils/config-sources.ts
+++ b/src/utils/config-sources.ts
@@ -9,7 +9,7 @@ export function stripCommit(version: string): string {
   }
 
   // If the version contains commit ==> hash remove it
-  return version.replace(/(-\w+)+$/g, '')
+  return version.replace('-stateful', '').replace(/-[0-9a-fA-F]{8}$/, '')
 }
 
 async function searchPackageJson(): Promise<string | undefined> {


### PR DESCRIPTION
The previous regex would remove valid release metadata like `-rc0`. This fix scopes it down to fixed hexadecimal 8 characters string which is the short commit hash.