### PR TITLE
feat: multiarch builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,6 +31,7 @@ env:
   COMMIT_VERSION_TAG: 'false'
   STATE_COMMIT: 'true'
   BEE_VERSION: '${{ github.event.client_payload.tag }}'
+  BEE_PLATFORM: 'linux/amd64,linux/arm64,linux/arm/v7'
 
 jobs:
   bee-images:
@@ -44,6 +45,15 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
 
       - name: Override inputs from `workflow_dispatch`
         run: |

--- a/generator/scripts/bee-docker-build.sh
+++ b/generator/scripts/bee-docker-build.sh
@@ -11,10 +11,17 @@ DOCKERFILE
 
 dockerbuild() {
   BLOCKCHAIN_VERSION=$("$MY_PATH/utils/env-variable-value.sh" BLOCKCHAIN_VERSION)
+  PLATFORM_FLAG=""
+
+  if [ -n "$BEE_PLATFORM" ]; then
+    # Multiplatform build needs to push the images right away as docker buildx does not output images loaded into
+    # docker itself, or it can do that but only for one platform.
+    PLATFORM_FLAG="--platform=$BEE_PLATFORM --push"
+  fi
 
   IMAGE_NAME=$(basename "$1")
   IMAGE_NAME="$4/$IMAGE_NAME"
-  docker build "$1" --no-cache -f "$2" -t "$IMAGE_NAME:$3" --label "org.ethswarm.beefactory.blockchain-version=$BLOCKCHAIN_VERSION"
+  docker build "$1" --no-cache -f "$2" -t "$IMAGE_NAME:$3" $PLATFORM_FLAG --label "org.ethswarm.beefactory.blockchain-version=$BLOCKCHAIN_VERSION"
 }
 
 MY_PATH=$(dirname "$0")


### PR DESCRIPTION
Closes #70 

So the Bee nodes are now supported with multi-arch build, but the blockchain container is not as the parent image ([truffle-cli](https://hub.docker.com/r/trufflesuite/ganache-cli)) itself does not support multiarch. We could build our own as it is more or less only node image + npm installed `ganache-cli`, but for now I don't think it is necessary.