### PR TITLE
feat: add withdrawal addresses whitelist

### DIFF
--- a/src/docker/manager.ts
+++ b/src/docker/manager.ts
@@ -208,6 +208,7 @@ function buildBeeCmd(
     `--redistribution-address=${contractAddresses.redistribution}`,
     `--swap-factory-address=${contractAddresses.swapFactory}`,
     `--postage-stamp-start-block=${contractAddresses.postageStampStartBlock}`,
+    '--withdrawal-addresses-whitelist="0xd238ff944bacb478cbed5efcae784d7bf4f2ff80"'
   ];
 
   if (bootnodeAddr) {


### PR DESCRIPTION
This is a random address that we can use to test BZZ and native token withdrawals (Bee exposes this functionality via endpoints)

See tests:
https://github.com/ethersphere/bee-js/blob/master/test/integration/withdraw.spec.ts
- withdraw to external wallet
- withdraw to unauthorized address