### PR TITLE
ci: authenticate release-please via GitHub App token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BEE_RUNNER_CLIENT_ID }}
+          private-key: ${{ secrets.BEE_RUNNER_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.REPO_GHA_PAT }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

`release.yaml` calls `googleapis/release-please-action@v4` with `secrets.REPO_GHA_PAT`, last rotated 2021-11-09. The token now returns `Bad credentials` from the GitHub API ([failing run](https://github.com/ethersphere/bee-factory/actions/runs/26050517272/job/76585680600)), so no release PRs are being created.

## Fix

Generate a fresh GitHub App token at workflow runtime using `actions/create-github-app-token@v1` with the org-level `BEE_RUNNER_CLIENT_ID` + `BEE_RUNNER_KEY` secrets, and pass that into release-please. Same pattern as ethersphere/create-swarm-app#13.

## Prerequisite

`BEE_RUNNER_KEY` is currently shared at the org level only with selected repos. An org admin needs to add `bee-factory` to its repository allowlist (Settings → Secrets and variables → Actions → `BEE_RUNNER_KEY` → repository access). `BEE_RUNNER_CLIENT_ID` is already visible to this repo.

After that grant, the next push to `master` should run release-please successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)