### PR TITLE
ci: use numeric App ID for create-github-app-token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BEE_RUNNER_CLIENT_ID }}
+          private-key: ${{ secrets.BEE_RUNNER_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.REPO_GHA_PAT }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.BEE_RUNNER_CLIENT_ID }}
+          app-id: ${{ secrets.BEE_RUNNER_APP_ID }}
           private-key: ${{ secrets.BEE_RUNNER_KEY }}
 
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
Follow-up to #292. The release-please run after that merge failed:

```
'Issuer' claim ('iss') must be an Integer
```

`actions/create-github-app-token` was passed `BEE_RUNNER_CLIENT_ID`, whose value is not numeric, so it ended up as the JWT `iss` claim that GitHub rejected. Switching to `BEE_RUNNER_APP_ID` (numeric) makes the claim valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)