### PR TITLE
ci: drop NODE_AUTH_TOKEN in favor of npm trusted publishing

### DIFF
--- a/.github/workflows/publish_npmjs.yaml
+++ b/.github/workflows/publish_npmjs.yaml
@@ -23,5 +23,3 @@ jobs:
       - run: npm ci
       - run: npm run build --if-present
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Removes `NODE_AUTH_TOKEN`/`NPM_TOKEN` env from the `npm publish` step in `publish_npmjs.yaml`.
- The workflow already requests `id-token: write` under the `publish` environment, and `@ethersphere/bee-factory` is registered as a trusted publisher on npmjs.com for this repo / workflow / environment.
- With the token gone, `npm publish --provenance` will authenticate via OIDC.

## Test plan
- [ ] Merge this PR
- [ ] Merge release-please PR #295 to cut a release and trigger `publish_npmjs.yaml`
- [ ] Confirm the publish step completes without `NPM_TOKEN` and the package appears on npm with a provenance attestation