### PR TITLE
fix: resync clock

### DIFF
--- a/src/blockchain/snapshot.ts
+++ b/src/blockchain/snapshot.ts
@@ -46,6 +46,61 @@ export async function saveSnapshot(addresses: ContractAddresses): Promise<void> 
   fs.writeFileSync(path.join(dir, 'anvil-state.json'), JSON.stringify(data, null, 2));
 }
 
+// Bee refuses to start on a chain whose head is older than this (maxDelay in
+// bee's pkg/node/chain.go, enforced by transaction.WaitSynced).
+const MAX_CLOCK_DRIFT_SECONDS = 60;
+
+/**
+ * Re-anchors the chain clock to wall clock after a state restore.
+ *
+ * Since foundry #15760 ("continue the saved timeline after loading state", in nightlies
+ * from 2026-08-07), anvil_loadState resets the node clock to the timestamp stored in the
+ * dump and keeps mining from there — so a restored chain stays exactly as far behind wall
+ * clock as the dump is old. Bee's startup sync check then never passes and every node hangs
+ * before libp2p comes up, which surfaces here as a queen bootnode timeout.
+ *
+ * On older anvil builds, which left the clock at wall time, this is a no-op.
+ */
+export async function resyncChainClock(): Promise<{ driftBefore: number; driftAfter: number }> {
+  const driftBefore = await chainClockDrift();
+
+  try {
+    await anvilJsonRpc('evm_setTime', [nowSeconds()]);
+  } catch {
+    // Anvil builds without evm_setTime never re-anchored the clock on load either, so
+    // their restored chain already runs at wall time. If it doesn't, the drift check
+    // below reports it.
+  }
+
+  // Bee reads the latest block header, not the pending block env, so the new timestamp
+  // only becomes visible once a block is mined. Interval mining would get there within
+  // --block-time seconds; mining explicitly removes the race.
+  await anvilJsonRpc('anvil_mine', ['0x1']);
+
+  const driftAfter = await chainClockDrift();
+  if (driftAfter > MAX_CLOCK_DRIFT_SECONDS) {
+    throw new Error(
+      `Chain head is ${driftAfter}s behind wall clock after re-anchoring (limit ${MAX_CLOCK_DRIFT_SECONDS}s). ` +
+      `Bee would hang in its startup blockchain sync check. Run with --fresh to redeploy from scratch.`
+    );
+  }
+
+  return { driftBefore, driftAfter };
+}
+
+/** Seconds by which the chain head trails wall clock. */
+async function chainClockDrift(): Promise<number> {
+  const block = (await anvilJsonRpc('eth_getBlockByNumber', ['latest', false])) as {
+    timestamp: string;
+  } | null;
+  if (!block) throw new Error('Anvil returned no latest block');
+  return nowSeconds() - parseInt(block.timestamp, 16);
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
 function anvilJsonRpc(method: string, params: unknown[]): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const body = JSON.stringify({ jsonrpc: '2.0', method, params, id: 1 });

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -12,7 +12,7 @@ import {
 } from '../config';
 import { deployContracts, ContractAddresses } from '../blockchain/deploy';
 import { fundNodes } from '../blockchain/fund';
-import { hasSnapshot, applySnapshot, saveSnapshot } from '../blockchain/snapshot';
+import { hasSnapshot, applySnapshot, saveSnapshot, resyncChainClock } from '../blockchain/snapshot';
 import { generateAllKeystores } from '../keystore';
 import {
   cleanupAll,
@@ -126,11 +126,13 @@ export async function start(options: StartOptions): Promise<void> {
 
   // 6. Deploy contracts + fund wallets, or restore from snapshot
   let addresses: ContractAddresses;
+  let restoredState = false;
 
   if (usePrebuilt) {
     const spinner = ora('Restoring Anvil state from pre-built image...').start();
     try {
       addresses = await restoreAnvilState();
+      restoredState = true;
       spinner.succeed(chalk.green('Anvil state restored from pre-built image.'));
     } catch (err) {
       spinner.fail(chalk.red('Failed to read contract addresses from pre-built image.'));
@@ -143,6 +145,7 @@ export async function start(options: StartOptions): Promise<void> {
     const spinner = ora('Loading Anvil state from snapshot...').start();
     try {
       addresses = await applySnapshot();
+      restoredState = true;
       spinner.succeed(chalk.green('Anvil state loaded from snapshot (contracts + funded wallets restored).'));
     } catch (err) {
       spinner.fail(chalk.red('Failed to load snapshot.'));
@@ -200,6 +203,25 @@ export async function start(options: StartOptions): Promise<void> {
     }
   }
   } // end else (not usePrebuilt)
+
+  // 6b. A restored chain carries the timestamps it was dumped with, and recent Anvil
+  // builds keep mining on that old timeline. Bee rejects a chain head older than a
+  // minute and blocks at startup, so pull the clock back to wall time before any node
+  // starts. Freshly deployed chains are already current.
+  if (restoredState) {
+    const spinner = ora('Re-anchoring chain clock to wall clock...').start();
+    try {
+      const { driftBefore, driftAfter } = await resyncChainClock();
+      spinner.succeed(
+        chalk.green(
+          `Chain clock re-anchored (head was ${driftBefore}s behind, now ${driftAfter}s).`
+        )
+      );
+    } catch (err) {
+      spinner.fail(chalk.red('Failed to re-anchor chain clock.'));
+      throw err;
+    }
+  }
 
   // 7. Generate keystore files. Skipped in prebuilt mode — the committed images
   // already contain swarm.key / libp2p_v2.key / pss.key for each node.


### PR DESCRIPTION
`resyncChainClock()` in `src/blockchain/snapshot.ts:49`, called from `start.ts:207` right after either restore path (pre-built image or local snapshot) and before any Bee node starts:

1. measures current head-vs-wall drift,
2. `evm_setTime` to now,
3. mines one block so the new timestamp lands in an actual header (Bee reads `HeaderByNumber(nil)`, not the pending env; interval mining would get there within `--block-time` seconds, this just removes the race),
4. re-measures and throws a self-explanatory error if the head is still >60s stale — matching Bee's maxDelay — instead of leaving you with the opaque bootnode timeout.
